### PR TITLE
Dont use server for shrinksafe minification when building Objective-J framework

### DIFF
--- a/Objective-J/Jakefile
+++ b/Objective-J/Jakefile
@@ -111,7 +111,7 @@ function environmentFlags()
 
 var SHRINKSAFE = require("minify/shrinksafe");
 function compressor(code) {
-    return SHRINKSAFE.compress(code, { charset : "UTF-8", useServer : true });
+    return SHRINKSAFE.compress(code, { charset : "UTF-8", useServer : false });
 }
 
 function gcc(inputFilePath, outputFilePath, flags, compress)


### PR DESCRIPTION
When running the Node engine it will hang as a subprocess is running when it tries to exit